### PR TITLE
Fixed boxplot width algorithms

### DIFF
--- a/lastplot/graph_constructor.py
+++ b/lastplot/graph_constructor.py
@@ -1,41 +1,72 @@
+import matplotlib.pyplot as plt
 import numpy as np
+from matplotlib.axes import Axes
 
 
-def mpl_calc_series(n_groups, n_bars, group_width, bar_width, bar_gap):
+def mpl_calc_series(
+    n_groups, n_bars, group_width, bar_width, bar_gap, min_bar_gap=0.01
+):
     # IMPORTANT: This algorithm only produces correct bar widths when the
     # figure's width is determined exclusively by the n_groups given.
     # When you combine the plot with other elements that change the x-axis
     # limits, the bars will be rescaled and have an incorrect width.
     bar_gap *= n_groups
     bar_width *= n_groups
-    min_bar_gap = min(bar_gap, 0.03)
+    min_bar_gap = min(bar_gap, min_bar_gap * n_groups)
     min_width = bar_width * n_bars + min_bar_gap * (n_bars - 1)
     if min_width > group_width:
-        algorithm = mpl_calc_scaled_group_series
-        bar_width = mpl_calc_bar_width(n_bars, group_width)
+        bar_gap = min_bar_gap
+        group_points = mpl_calc_scaled_group_series(n_bars, group_width, bar_gap)
+        bar_width = mpl_calc_bar_width(n_bars, group_width, bar_gap)
     else:
         if bar_width * n_bars + bar_gap * (n_bars - 1) > group_width:
             bar_gap = (group_width - n_bars * bar_width) / (n_bars - 1)
-        algorithm = mpl_calc_clustered_group_series
-    group_points = algorithm(n_bars, group_width, bar_width, bar_gap)
+        group_points = mpl_calc_clustered_group_series(n_bars, bar_width, bar_gap)
     return bar_width, [i + group_points for i in range(n_groups)]
 
 
-def mpl_calc_scaled_group_series(n_bars, group_width, bar_width, bar_gap):
+def mpl_calc_scaled_group_series(n_bars, group_width, bar_gap):
     width = max(1, n_bars - 1)
     half_width = width / 2
     centered = np.arange(n_bars) - half_width
-    bar_width = mpl_calc_bar_width(n_bars, group_width)
+    bar_width = mpl_calc_bar_width(n_bars, group_width, bar_gap)
     return centered / width * (group_width - bar_width)
 
 
-def mpl_calc_clustered_group_series(n_bars, group_width, bar_width, bar_gap):
+def mpl_calc_clustered_group_series(n_bars, bar_width, bar_gap):
     hop = bar_width + bar_gap
     return np.array([hop * i - (hop * (n_bars - 1)) / 2 for i in range(n_bars)])
 
 
-def mpl_calc_bar_width(n_bars, group_width):
-    estimate = (group_width - 0.03 * n_bars) / n_bars
-    for i in range(50):
-        estimate = ((group_width - estimate) - 0.03 * n_bars) / n_bars
-    return estimate
+def mpl_calc_bar_width(n_bars, group_width, gap):
+    return (group_width - gap * (n_bars - 1)) / n_bars
+
+
+def mpl_debug_series(
+    n_groups, n_bars, group_width, bar_width, bar_gap, ax: Axes, min_bar_gap=0.03
+):
+    print("HUH?", bar_width, bar_gap)
+    debug = f"Input: w{bar_width:.2f}, g{bar_gap:.2f};"
+    bar_gap *= n_groups
+    bar_width *= n_groups
+    min_bar_gap = min(bar_gap, min_bar_gap)
+    full_width = bar_width * n_bars + bar_gap * (n_bars - 1)
+    min_width = bar_width * n_bars + min_bar_gap * (n_bars - 1)
+    debug += f" Zoomed: w{bar_width:.2f}, g{bar_gap:.2f}, fw{full_width:.2f}, mw{min_width:.2f};"
+    if min_width > group_width:
+        algorithm = "scaled"
+        bar_gap = min_bar_gap
+        bar_width = mpl_calc_bar_width(n_bars, group_width, min_bar_gap)
+    else:
+        if full_width > group_width:
+            bar_gap = (group_width - n_bars * bar_width) / (n_bars - 1)
+            algorithm = "clustered"
+        else:
+            algorithm = "gapped"
+    debug += f" Calc: w{bar_width:.2f}, g{bar_gap:.2f}, {algorithm};"
+    mpl_calc_series(n_groups, n_bars, group_width, bar_width, bar_gap)
+    ax.axhline(0, linestyle="--", color="k")
+    for x in range(n_groups):
+        ax.axvline(x, color="gray", linewidth=0.5)
+        ax.axvspan(x - group_width / 2, x + group_width / 2, alpha=0.5, color="red")
+    ax.text(0, 0, debug, fontsize=8, transform=ax.transAxes)

--- a/lastplot/graph_constructor.py
+++ b/lastplot/graph_constructor.py
@@ -1,4 +1,3 @@
-import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.axes import Axes
 
@@ -45,7 +44,6 @@ def mpl_calc_bar_width(n_bars, group_width, gap):
 def mpl_debug_series(
     n_groups, n_bars, group_width, bar_width, bar_gap, ax: Axes, min_bar_gap=0.03
 ):
-    print("HUH?", bar_width, bar_gap)
     debug = f"Input: w{bar_width:.2f}, g{bar_gap:.2f};"
     bar_gap *= n_groups
     bar_width *= n_groups

--- a/lastplot/log10_graphs.py
+++ b/lastplot/log10_graphs.py
@@ -6,7 +6,7 @@ import seaborn as sns
 import starbars
 
 from lastplot.computing_statistics import get_test, get_pvalue
-from lastplot.graph_constructor import mpl_calc_series
+from lastplot.graph_constructor import mpl_calc_series, mpl_debug_series
 from lastplot.saving import save_sheet
 
 __all__ = [
@@ -17,7 +17,15 @@ __all__ = [
 
 # Graphs by log10 values
 def log_values_graph_lipid(
-    df_final, control_name, experimental_name, output_path, palette, xlabel=None, ylabel=None, title=None, show=True
+    df_final,
+    control_name,
+    experimental_name,
+    output_path,
+    palette,
+    xlabel=None,
+    ylabel=None,
+    title=None,
+    show=True,
 ):
     """
     The `log_values_graph_lipid` function generates boxplots and statistical annotations to visualize the distribution of log 10 transformed values of single lipids across regions. It performs the following tasks:
@@ -43,7 +51,7 @@ def log_values_graph_lipid(
     """
 
     group_width = 0.4
-    bar_width = 0.
+    bar_width = 0.0
     bar_gap = 0.02
     palette = sns.color_palette(palette)
 
@@ -93,7 +101,13 @@ def log_values_graph_lipid(
         )
 
         # Add scatterplot
-        ax.scatter(np.ones(len(control_values)) * positions[0], control_values, color="k", s=6, zorder=3)
+        ax.scatter(
+            np.ones(len(control_values)) * positions[0],
+            control_values,
+            color="k",
+            s=6,
+            zorder=3,
+        )
         ax.scatter(
             np.ones(len(experimental_values)) * positions[1],
             experimental_values,
@@ -124,7 +138,8 @@ def log_values_graph_lipid(
             ax.set_title(f"Log10 Transformed Values for {lipid} in {region}")
 
         plt.savefig(
-            output_path + f"/output/log_value_graphs/lipid/Log10 Transformed Values for {lipid} in {region}.png",
+            output_path
+            + f"/output/log_value_graphs/lipid/Log10 Transformed Values for {lipid} in {region}.png",
             dpi=1200,
         )
         if show:
@@ -133,7 +148,16 @@ def log_values_graph_lipid(
 
 
 def log_values_graph_lipid_class(
-    df_final, control_name, experimental_name, output_path, palette, xlabel=None, ylabel=None, title=None, show=True
+    df_final,
+    control_name,
+    experimental_name,
+    output_path,
+    palette,
+    xlabel=None,
+    ylabel=None,
+    title=None,
+    show=True,
+    debug=False,
 ):
     """
     The `log_values_graph_lipid_class` function generates boxplots to visualize the distribution of log 10 transformed values across different lipid classes within each region. It performs the following tasks:
@@ -156,9 +180,9 @@ def log_values_graph_lipid_class(
     :param show: Whether to display plots interactively (default True).
     """
 
-    group_width = 0.5 # space a group will take (all expressed in percentages)
-    bar_width = 0.03 # width of one boxplot
-    bar_gap = 0.01 # space in between groups
+    group_width = 0.5  # space a group will take (all expressed in percentages)
+    bar_width = 0.03  # width of one boxplot
+    bar_gap = 0.01  # space in between groups
 
     palette = sns.color_palette(palette)
 
@@ -175,24 +199,38 @@ def log_values_graph_lipid_class(
             data = region_data[region_data["Lipid Class"] == lipid_class]
             lipids = data["Lipids"].unique()
 
-            bar_width, positions = mpl_calc_series(
-                len(lipids), 2, group_width=group_width, bar_width=bar_width, bar_gap=bar_gap
-            ) # len(lipids) is the lenght of the ticks
-            print("bar parameters", bar_gap, bar_width, group_width)
+            if debug:
+                # Draw extra information to visualize the bar width calculations.
+                mpl_debug_series(
+                    len(lipids),
+                    2,
+                    group_width=group_width,
+                    bar_width=bar_width,
+                    bar_gap=bar_gap,
+                    ax=ax,
+                )
+
+            comp_bar_width, positions = mpl_calc_series(
+                len(lipids),
+                2,
+                group_width=group_width,
+                bar_width=bar_width,
+                bar_gap=bar_gap,
+            )  # len(lipids) is the lenght of the ticks
 
             for j, lipid in enumerate(lipids):
-                control_values = data[(data["Lipids"] == lipid) & (data["Genotype"] == control_name)][
-                    "Log10 Transformed"
-                ]
-                experimental_values = data[(data["Lipids"] == lipid) & (data["Genotype"] == experimental_name)][
-                    "Log10 Transformed"
-                ]
+                control_values = data[
+                    (data["Lipids"] == lipid) & (data["Genotype"] == control_name)
+                ]["Log10 Transformed"]
+                experimental_values = data[
+                    (data["Lipids"] == lipid) & (data["Genotype"] == experimental_name)
+                ]["Log10 Transformed"]
 
                 # Create boxplots
                 ax.boxplot(
                     control_values,
                     positions=[positions[j][0]],
-                    widths=bar_width,
+                    widths=comp_bar_width,
                     patch_artist=True,
                     boxprops=dict(facecolor=palette[0], color="k"),
                     medianprops=dict(color="k"),
@@ -200,7 +238,7 @@ def log_values_graph_lipid_class(
                 ax.boxplot(
                     experimental_values,
                     positions=[positions[j][1]],
-                    widths=bar_width,
+                    widths=comp_bar_width,
                     patch_artist=True,
                     boxprops=dict(facecolor=palette[1], color="k"),
                     medianprops=dict(color="k"),


### PR DESCRIPTION
The `scaled` width algorithm created too much gap. This is now properly configurable by passing a `mpl_calc_series(..., min_bar_gap=0.01)` optional keyword argument.

I've also added an analog `mpl_debug_series` function which draws additional information on a given `ax` to check the calculations.